### PR TITLE
Server.properties worldtype patch(until Forge fixes it). "use-modded-worldtype=terraforged"

### DIFF
--- a/TerraForgedMod/build.gradle
+++ b/TerraForgedMod/build.gradle
@@ -1,4 +1,4 @@
-buildscript {
+    buildscript {
     repositories {
         jcenter()
         mavenCentral()
@@ -37,6 +37,9 @@ dependencies {
 
 minecraft {
     mappings channel: mcp_channel, version: mcp_version
+
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+
     runs {
         client {
             workingDirectory project.file("run/client")

--- a/TerraForgedMod/src/main/java/com/terraforged/mod/TerraForgedMod.java
+++ b/TerraForgedMod/src/main/java/com/terraforged/mod/TerraForgedMod.java
@@ -32,6 +32,7 @@ import com.terraforged.mod.data.DataGen;
 import com.terraforged.mod.feature.tree.SaplingManager;
 import com.terraforged.mod.settings.SettingsHelper;
 import com.terraforged.mod.util.Environment;
+import net.minecraft.server.dedicated.ServerProperties;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
@@ -78,5 +79,25 @@ public class TerraForgedMod {
 
     private static void onShutdown(FMLServerStoppingEvent event) {
         ThreadPool.shutdownCurrent();
+    }
+
+
+    @SubscribeEvent
+    public void dedicatedServerSetup(FMLDedicatedServerSetupEvent event)
+    {
+        ServerProperties serverProperties = event.getServerSupplier().get().getServerProperties();
+
+        if(serverProperties != null)
+        {
+            //get entry if it exists or null if it doesn't
+            String entryValue = serverProperties.serverProperties.getProperty("use-modded-worldtype");
+
+            if(entryValue != null && entryValue.equals("terraforged"))
+            {
+                //make server use our worldtype
+                serverProperties.worldType = TerraWorld.TERRA;
+            }
+        }
+        //In server.properties use this line: `use-modded-worldtype=terraforged`
     }
 }

--- a/TerraForgedMod/src/main/java/com/terraforged/mod/TerraForgedMod.java
+++ b/TerraForgedMod/src/main/java/com/terraforged/mod/TerraForgedMod.java
@@ -66,7 +66,9 @@ public class TerraForgedMod {
         }
     }
 
+    //
     @SubscribeEvent
+    //FoundSpore: Possibly useless event with the other method `serverSetup` replacing this.
     public static void server(FMLDedicatedServerSetupEvent event) {
         Log.info("Setting dedicated server");
         SettingsHelper.setDedicatedServer();
@@ -80,13 +82,10 @@ public class TerraForgedMod {
     private static void onShutdown(FMLServerStoppingEvent event) {
         ThreadPool.shutdownCurrent();
     }
-
-
     @SubscribeEvent
-    public void dedicatedServerSetup(FMLDedicatedServerSetupEvent event)
+    public static void serverSetup(FMLDedicatedServerSetupEvent event)
     {
         ServerProperties serverProperties = event.getServerSupplier().get().getServerProperties();
-
         if(serverProperties != null)
         {
             //get entry if it exists or null if it doesn't
@@ -96,6 +95,7 @@ public class TerraForgedMod {
             {
                 //make server use our worldtype
                 serverProperties.worldType = TerraWorld.TERRA;
+                Log.info("TerraForged world type set for server!");
             }
         }
         //In server.properties use this line: `use-modded-worldtype=terraforged`

--- a/TerraForgedMod/src/main/resources/META-INF/accesstransformer.cfg
+++ b/TerraForgedMod/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,2 @@
+public net.minecraft.server.dedicated.PropertyManager field_73672_b # serverProperties
+public-f net.minecraft.server.dedicated.ServerProperties field_219023_q # worldType


### PR DESCRIPTION
Added a new server.properties rule that other mods have used to allow their world types be hosted on servers. Servers will now be able generate new chunks with the TerraForged Generator. In TerraForgedMod, Added an accesstransformer under META-INF as well as a accesstransformer listener in the build.gradle.

Here's the new server.properties line:
**use-modded-worldtype=terraforged**

https://i.imgur.com/cSjCWfE.mp4