### PR TITLE
Freshen up and somewhat standardize command returns

### DIFF
--- a/src/main/java/com/terraforged/mod/server/command/TerraCommand.java
+++ b/src/main/java/com/terraforged/mod/server/command/TerraCommand.java
@@ -247,7 +247,7 @@ public class TerraCommand {
         int identifier = doSearch(server, playerID, search);
         context.getSource().sendFeedback(createPrefix(identifier)
                                          .appendSibling(new StringTextComponent(" Searching for "))
-                                         .appendSibling(createTitleWithHover(biome.getDisplayName().getFormattedText(), biome.getRegistryName().toString()))
+                                         .appendSibling(createTitle(biome.getRegistryName().toString()))
                                          .appendSibling(new StringTextComponent("..."))
                                          , false);
 
@@ -274,7 +274,7 @@ public class TerraCommand {
         int identifier = doSearch(server, playerID, search);
         context.getSource().sendFeedback(createPrefix(identifier)
                                          .appendSibling(new StringTextComponent(" Searching for "))
-                                         .appendSibling(createTitleWithHover(biome.getDisplayName().getFormattedText(), biome.getRegistryName().toString()))
+                                         .appendSibling(createTitle(biome.getRegistryName().toString()))
                                          .appendSibling(new StringTextComponent(" and "))
                                          .appendSibling(createTitle(target.getName()))
                                          .appendSibling(new StringTextComponent("..."))
@@ -366,12 +366,5 @@ public class TerraCommand {
     private static ITextComponent createTitle(String name) {
         return new StringTextComponent("") // Gotta make sure parent style is default
                    .appendSibling(new StringTextComponent(name).applyTextStyle(TITLE_FORMAT));
-    }
-
-    private static ITextComponent createTitleWithHover(String display, String hover) {
-        return createTitle(display)
-                .appendSibling(new StringTextComponent(hover)
-                    .applyTextStyle((style) -> style.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, createTitle(hover))))
-                );
     }
 }


### PR DESCRIPTION
Responding to #250 

- Added a bit more info to `/terra debug` and `/terra query` returns
- Added in biome and terrain strings to `/terra locate` returns
- Added "search ids" to `/terra locate` commands because adding strings would require too much rework, and this accounts for long-running searches.
- Attempted to somewhat standardize command returns (biome and terrain display names are dark green, biome types and registered names are italicized, ...). See screenshot below
- Added _y_ coordinate to position display to erase confusion (_y_ coordinate was already set in `/tp` command)

![image](https://user-images.githubusercontent.com/11185929/89490902-c8920100-d762-11ea-821e-6eee0ceb3e87.png)
